### PR TITLE
fix issue with relative enabled 

### DIFF
--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -98,7 +98,7 @@ class HashidBehavior extends Behavior {
 		$query->find('hashed');
 
 		$idField = $this->_primaryKey;
-		if ($field === $idField) {
+		if ($primary && $field === $idField) {
 			$query->traverseExpressions(function ($expression) {
 				if (method_exists($expression, 'getField')
 					&& ($expression->getField() === $this->_primaryKey || $expression->getField() === $this->_table->alias() . '.' . $this->_primaryKey)


### PR DESCRIPTION
This is a (multiple allowed):
- [x] bug
- [x] enhancement
- [ ] feature-discussion (RFC)
### What you did

ACTIVATED THE BEHAVIOR ON THE MAIN TABLE AND SET THE `'recursive' = true`.
### Expected Behavior

THE MAIN TABLE IDs IS HASHED WHEN I BROWS THE ASSOCIATED TABLE
### Actual Behavior

NO RECORD RETRIEVED FROM THE DATABASE AND RAISED AN ERROR IN [THIS LINE](https://github.com/dereuromark/cakephp-hashid/blob/master/src/Model/HashidTrait.php#L47):

> Warning (2): strpos() expects parameter 1 to be string, object given [ROOT\vendor\dereuromark\cakephp-hashid\src\Model\HashidTrait.php, line 47]

I CHECKED THE `$hashid` PARAMITER IT IS :

```
object(Cake\Database\Expression\IdentifierExpression)[263]
  protected '_identifier' => string 'Categories.app_id' (length=17)
```

THE PROBLEM IS FIXED BY THIS PATCH
