### PR TITLE
check if entity before call the dirty function

### DIFF
--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -231,7 +231,9 @@ class HashidBehavior extends Behavior {
 				}
 
 				$row[$field] = $this->encodeId($row[$idField]);
-				$row->dirty($field, false);
+				if($row instanceof Entity){
+					$row->dirty($field, false);
+				}
 				return $row;
 			});
 		});

--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -231,7 +231,7 @@ class HashidBehavior extends Behavior {
 				}
 
 				$row[$field] = $this->encodeId($row[$idField]);
-				if($row instanceof Entity) {
+				if ($row instanceof Entity) {
 					$row->dirty($field, false);
 				}
 				return $row;

--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -231,7 +231,7 @@ class HashidBehavior extends Behavior {
 				}
 
 				$row[$field] = $this->encodeId($row[$idField]);
-				if($row instanceof Entity){
+				if($row instanceof Entity) {
 					$row->dirty($field, false);
 				}
 				return $row;


### PR DESCRIPTION
This is necessary when we set hydrate to false 

```
        $apps = $this->Apps->find()->where([
            'user_id' => $user['user']['id']
        ])->hydrate(false)->first();
```
