### PR TITLE
Added minHashLength and alphabet options

### DIFF
--- a/src/Model/HashidTrait.php
+++ b/src/Model/HashidTrait.php
@@ -3,6 +3,7 @@
 namespace Hashid\Model;
 
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Utility\Hash;
 use Hashids\Hashids;
 
 /**
@@ -58,7 +59,7 @@ trait HashidTrait {
 		if (isset($this->_hashids)) {
 			return $this->_hashids;
 		}
-		$this->_hashids = new Hashids($this->_config['salt']);
+		$this->_hashids = new Hashids($this->_config['salt'], Hash::get($this->_config, 'minHashLength', 0), Hash::get($this->_config, 'alphabet', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'));
 
 		return $this->_hashids;
 	}


### PR DESCRIPTION
Fixes #4.

Ideally there would be tests in place to ensure each of these options changes the result (i.e. setting the `minHashLength` to `5` results in ids being at least 5 characters long).

Working on getting existing tests to pass.