### PR TITLE
existsHashed() for exists()

### DIFF
--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -50,7 +50,10 @@ class HashidBehavior extends Behavior {
 		'findFirst' => false, // Either true or 'first' or 'firstOrFail'
 		'implementedFinders' => [
 			'hashed' => 'findHashed',
-		]
+		],
+		'implementedMethods' => [
+			'existsHashed' => 'existsHashed',
+		],
 	];
 
 	/**
@@ -259,6 +262,22 @@ class HashidBehavior extends Behavior {
 			return $query;
 		}
 		return $query->first();
+	}
+
+	/**
+	 * @param string|array|\Cake\Database\ExpressionInterface|callable $conditions
+	 *
+	 * @return bool
+	 */
+	public function existsHashed($conditions) {
+		return (bool)count(
+			$this->_table->find()
+				->select($this->_table->primaryKey())
+				->where($conditions)
+				->limit(1)
+				->enableHydration(false)
+				->toArray()
+		);
 	}
 
 }

--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -54,7 +54,7 @@ class HashidBehavior extends Behavior {
 		'implementedMethods' => [
 			'decode' => 'decode',
 			'encode' => 'encode',
-			'existsHashed' => 'existsHashed',
+			'exists' => 'existsHashed',
 		],
 	];
 

--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -52,6 +52,8 @@ class HashidBehavior extends Behavior {
 			'hashed' => 'findHashed',
 		],
 		'implementedMethods' => [
+			'decode' => 'decode',
+			'encode' => 'encode',
 			'existsHashed' => 'existsHashed',
 		],
 	];

--- a/tests/TestCase/Model/Behavior/HashidBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/HashidBehaviorTest.php
@@ -243,7 +243,7 @@ class HashidBehaviorTest extends TestCase {
 		$this->Addresses->behaviors()->Hashid->config('field', false);
 
 		$address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
-		$hashid = $this->Addresses->encodeId($address->id);
+		$hashid = $this->Addresses->behaviors()->Hashid->encodeId($address->id);
 
 		$this->Addresses->behaviors()->Hashid->config('field', 'hash');
 
@@ -263,7 +263,7 @@ class HashidBehaviorTest extends TestCase {
 		$this->Addresses->behaviors()->Hashid->config('field', 'id');
 
 		$address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
-		$hashid = $this->Addresses->encodeId($address->getOriginal('id'));
+		$hashid = $this->Addresses->behaviors()->Hashid->encodeId($address->getOriginal('id'));
 		$this->assertSame($hashid, $address->id);
 
 		$address = $this->Addresses->patchEntity($address, ['postal_code' => '678']);


### PR DESCRIPTION
https://github.com/dereuromark/cakephp-hashid/issues/13

or is there a better way to provide this?
Would be nice if the core used `->select($this->_table->primaryKey())`.