### PR TITLE
Fixed a bug where the formatResults function in the findHashed method was wiping out the resultset.

### DIFF
--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -241,6 +241,8 @@ class HashidBehavior extends Behavior {
 					$newResult[] = $row;
 				} elseif (is_string($row)) {
 					$newResult[$this->encodeId($key)] = $row;
+				} else {
+					$newResult[] = $row;
 				}
 			});
 

--- a/tests/TestCase/Model/Behavior/HashidBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/HashidBehaviorTest.php
@@ -392,4 +392,28 @@ class HashidBehaviorTest extends TestCase {
 		$this->assertSame($hashid, $result->user->id);
 	}
 
+	/**
+	 * testIsUniqueDomainRule method
+	 *
+	 * @return void
+	 */
+	public function testIsUniqueDomainRule() {
+		$data = [
+			'city' => 'Foo',
+		];
+
+		$address = $this->Addresses->newEntity($data);
+		$result = $this->Addresses->save($address);
+		$this->assertTrue((bool)$result);
+
+		$rules = $this->Addresses->rulesChecker();
+		$rules->add($rules->isUnique(['city']));
+
+		$address = $this->Addresses->newEntity($data);
+		$result = $this->Addresses->save($address);
+
+		$this->assertFalse((bool)$result);
+		$this->assertEquals(['_isUnique' => 'This value is already in use'], $address->errors('city'));
+	}
+
 }


### PR DESCRIPTION
I added a catchall condition that keeps `newResult` from becoming empty.

I ran into this issue on my own, but I believe it is a fix for https://github.com/dereuromark/cakephp-hashid/issues/11 and possibly also https://github.com/dereuromark/cakephp-hashid/issues/13