### PR TITLE
Use latest hashids release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 
@@ -14,10 +12,10 @@ env:
 
 matrix:
   include:
-  
+
     - php: 7.1
       env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-  
+
     - php: 7.1
       env: PHPCS=1 DEFAULT=0
 

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
+		"php": "^7.1.3",
 		"cakephp/cakephp": "^3.5",
-		"hashids/hashids": "^1.0|^2.0"
+		"hashids/hashids": "^3.0"
 	},
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "dev-master"


### PR DESCRIPTION
Resolves #20 

The aim of this pull request is to upgrade the plugin to using the latest version of the `hashids/hashids` library.

The latest release has a higher PHP requirement too, so this is also reflected in this pull request.

The current test suite passes with the new version without issues on PHP Unit `6.5.13`