### PR TITLE
Upgrade codesniffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
 
 matrix:
   include:
-  
+
     - php: 7.1
       env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-  
+
     - php: 7.1
       env: PHPCS=1 DEFAULT=0
 
@@ -44,7 +44,7 @@ before_script:
 
 script:
   - if [[ $DEFAULT == 1 ]]; then vendor/bin/phpunit ; fi
-  - if [[ $PHPCS == 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --ignore=vendor --ignore=docs . ; fi
+  - if [[ $PHPCS == 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP/ --ignore=vendor --ignore=docs ./src ./tests ; fi
 
   - if [[ $CODECOVERAGE == 1 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml || true; fi
   - if [[ $CODECOVERAGE == 1 ]]; then wget -O codecov.sh https://codecov.io/bash; fi

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"hashids/hashids": "^1.0|^2.0"
 	},
 	"require-dev": {
-		"fig-r/psr2r-sniffer": "dev-master"
+		"cakephp/cakephp-codesniffer": "^3.0"
 	},
 	"autoload": {
 		"psr-4": {
@@ -37,7 +37,7 @@
 	"scripts": {
 		"test": "php phpunit.phar",
 		"test-setup": "[ ! -f phpunit.phar ] && wget https://phar.phpunit.de/phpunit-5.7.20.phar && mv phpunit-5.7.20.phar phpunit.phar || true",
-		"cs-check": "phpcs -p --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --ignore=/cakephp-hashid/vendor/,/tmp/,/logs/ --extensions=php ./",
-		"cs-fix": "phpcbf --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --ignore=/cakephp-hashid/vendor/,/tmp/,/logs/ --extensions=php ./"
+		"cs-check": "phpcs -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP/ --extensions=php ./src ./tests",
+		"cs-fix": "phpcbf -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP/ --extensions=php ./src ./tests"
 	}
 }

--- a/src/Model/Behavior/HashidBehavior.php
+++ b/src/Model/Behavior/HashidBehavior.php
@@ -16,249 +16,259 @@ use Hashid\Model\HashidTrait;
  * @author Mark Scherer
  * @license MIT
  */
-class HashidBehavior extends Behavior {
+class HashidBehavior extends Behavior
+{
 
-	use HashidTrait;
+    use HashidTrait;
 
-	const HID = 'hid';
+    const HID = 'hid';
 
-	/**
-	 * @var \Hashids\Hashids
-	 */
-	protected $_hashids;
+    /**
+     * @var \Hashids\Hashids
+     */
+    protected $_hashids;
 
-	/**
-	 * @var \Cake\ORM\Table
-	 */
-	protected $_table;
+    /**
+     * @var \Cake\ORM\Table
+     */
+    protected $_table;
 
-	/**
-	 * @var array|string
-	 */
-	protected $_primaryKey;
+    /**
+     * @var array|string
+     */
+    protected $_primaryKey;
 
-	/**
-	 * @var array
-	 */
-	protected $_defaultConfig = [
-		'salt' => null, // Please provide your own salt via Configure key 'Hashid.salt'
-		'field' => null, // To populate upon find() and save(), false to deactivate
-		'debug' => null, // Auto-detect from Configure::read('debug')
-		'minHashLength' => 0, // You can overwrite the Hashid defaults
-		'alphabet' => null, // You can overwrite the Hashid defaults
-		'recursive' => false, // Also transform nested entities
-		'findFirst' => false, // Either true or 'first' or 'firstOrFail'
-		'implementedFinders' => [
-			'hashed' => 'findHashed',
-		]
-	];
+    /**
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'salt' => null, // Please provide your own salt via Configure key 'Hashid.salt'
+        'field' => null, // To populate upon find() and save(), false to deactivate
+        'debug' => null, // Auto-detect from Configure::read('debug')
+        'minHashLength' => 0, // You can overwrite the Hashid defaults
+        'alphabet' => null, // You can overwrite the Hashid defaults
+        'recursive' => false, // Also transform nested entities
+        'findFirst' => false, // Either true or 'first' or 'firstOrFail'
+        'implementedFinders' => [
+            'hashed' => 'findHashed',
+        ]
+    ];
 
-	/**
-	 * Constructor
-	 *
-	 * Merges config with the default and store in the config property
-	 *
-	 * Does not retain a reference to the Table object. If you need this
-	 * you should override the constructor.
-	 *
-	 * @param \Cake\ORM\Table $table The table this behavior is attached to.
-	 * @param array $config The config for this behavior.
-	 */
-	public function __construct(Table $table, array $config = []) {
-		$defaults = (array)Configure::read('Hashid');
-		parent::__construct($table, $config + $defaults);
+    /**
+     * Constructor
+     *
+     * Merges config with the default and store in the config property
+     *
+     * Does not retain a reference to the Table object. If you need this
+     * you should override the constructor.
+     *
+     * @param \Cake\ORM\Table $table The table this behavior is attached to.
+     * @param array $config The config for this behavior.
+     */
+    public function __construct(Table $table, array $config = [])
+    {
+        $defaults = (array)Configure::read('Hashid');
+        parent::__construct($table, $config + $defaults);
 
-		$this->_table = $table;
-		$this->_primaryKey = $table->getPrimaryKey();
+        $this->_table = $table;
+        $this->_primaryKey = $table->getPrimaryKey();
 
-		if ($this->_config['salt'] === null) {
-			$this->_config['salt'] = Configure::read('Security.salt') ? sha1(Configure::read('Security.salt')) : null;
-		}
-		if ($this->_config['debug'] === null) {
-			$this->_config['debug'] = Configure::read('debug');
-		}
-		if ($this->_config['field'] === null) {
-			$this->_config['field'] = $this->_primaryKey;
-		}
-	}
+        if ($this->_config['salt'] === null) {
+            $this->_config['salt'] = Configure::read('Security.salt') ? sha1(Configure::read('Security.salt')) : null;
+        }
+        if ($this->_config['debug'] === null) {
+            $this->_config['debug'] = Configure::read('debug');
+        }
+        if ($this->_config['field'] === null) {
+            $this->_config['field'] = $this->_primaryKey;
+        }
+    }
 
-	/**
-	 * @param \Cake\Event\Event $event
-	 * @param \Cake\ORM\Query $query
-	 * @param \ArrayObject $options
-	 * @param bool $primary
-	 * @return void
-	 */
-	public function beforeFind(Event $event, Query $query, ArrayObject $options, $primary) {
-		if (!$primary && !$this->_config['recursive']) {
-			return;
-		}
+    /**
+     * @param \Cake\Event\Event $event
+     * @param \Cake\ORM\Query $query
+     * @param \ArrayObject $options
+     * @param bool $primary
+     * @return void
+     */
+    public function beforeFind(Event $event, Query $query, ArrayObject $options, $primary)
+    {
+        if (!$primary && !$this->_config['recursive']) {
+            return;
+        }
 
-		$field = $this->_config['field'];
-		if (!$field) {
-			return;
-		}
+        $field = $this->_config['field'];
+        if (!$field) {
+            return;
+        }
 
-		$query->find('hashed');
+        $query->find('hashed');
 
-		$idField = $this->_primaryKey;
-		if ($primary && $field === $idField) {
-			$query->traverseExpressions(function (ExpressionInterface $expression) {
-				if (method_exists($expression, 'getField')
-					&& ($expression->getField() === $this->_primaryKey || $expression->getField() === $this->_table->getAlias() . '.' . $this->_primaryKey)
-				) {
-					/** @var \Cake\Database\Expression\Comparison $expression */
-					$expression->setValue($this->decodeHashid($expression->getValue()));
-				}
-				return $expression;
-			});
-		}
+        $idField = $this->_primaryKey;
+        if ($primary && $field === $idField) {
+            $query->traverseExpressions(function (ExpressionInterface $expression) {
+                if (method_exists($expression, 'getField')
+                    && ($expression->getField() === $this->_primaryKey || $expression->getField() === $this->_table->getAlias() . '.' . $this->_primaryKey)
+                ) {
+                    /** @var \Cake\Database\Expression\Comparison $expression */
+                    $expression->setValue($this->decodeHashid($expression->getValue()));
+                }
 
-		if (!$this->_config['recursive']) {
-			return;
-		}
+                return $expression;
+            });
+        }
 
-		foreach ($this->_table->associations() as $association) {
-			if ($association->getTarget()->hasBehavior('Hashid') && $association->getFinder() === 'all') {
-				$association->setFinder('hashed');
-			}
-		}
-	}
+        if (!$this->_config['recursive']) {
+            return;
+        }
 
-	/**
-	 * @param \Cake\Event\Event $event The beforeSave event that was fired
-	 * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
-	 * @return void
-	 */
-	public function beforeSave(Event $event, EntityInterface $entity) {
-		if ($entity->isNew()) {
-			return;
-		}
+        foreach ($this->_table->associations() as $association) {
+            if ($association->getTarget()->hasBehavior('Hashid') && $association->getFinder() === 'all') {
+                $association->setFinder('hashed');
+            }
+        }
+    }
 
-		$this->decode($entity);
-	}
+    /**
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
+     * @return void
+     */
+    public function beforeSave(Event $event, EntityInterface $entity)
+    {
+        if ($entity->isNew()) {
+            return;
+        }
 
-	/**
-	 * @param \Cake\Event\Event $event The beforeSave event that was fired
-	 * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
-	 * @param \ArrayObject $options the options passed to the save method
-	 * @return void
-	 */
-	public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options) {
-		$this->encode($entity);
-	}
+        $this->decode($entity);
+    }
 
-	/**
-	 * @param \Cake\Event\Event $event
-	 * @param \Cake\Datasource\EntityInterface $entity
-	 * @param \ArrayObject $options
-	 * @return void
-	 */
-	public function beforeDelete(Event $event, EntityInterface $entity, ArrayObject $options) {
-		$this->decode($entity);
-	}
+    /**
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
+     * @param \ArrayObject $options the options passed to the save method
+     * @return void
+     */
+    public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    {
+        $this->encode($entity);
+    }
 
-	/**
-	 * Sets up hashid for model.
-	 *
-	 * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
-	 * @return bool True if save should proceed, false otherwise
-	 */
-	public function decode(EntityInterface $entity) {
-		$idField = $this->_primaryKey;
-		$hashid = $entity->get($idField);
-		if (!$hashid) {
-			return false;
-		}
+    /**
+     * @param \Cake\Event\Event $event
+     * @param \Cake\Datasource\EntityInterface $entity
+     * @param \ArrayObject $options
+     * @return void
+     */
+    public function beforeDelete(Event $event, EntityInterface $entity, ArrayObject $options)
+    {
+        $this->decode($entity);
+    }
 
-		$field = $this->_config['field'];
-		if (!$field) {
-			return false;
-		}
+    /**
+     * Sets up hashid for model.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
+     * @return bool True if save should proceed, false otherwise
+     */
+    public function decode(EntityInterface $entity)
+    {
+        $idField = $this->_primaryKey;
+        $hashid = $entity->get($idField);
+        if (!$hashid) {
+            return false;
+        }
 
-		$id = $this->decodeHashid($hashid);
+        $field = $this->_config['field'];
+        if (!$field) {
+            return false;
+        }
 
-		$entity->set($field, $id);
-		$entity->setDirty($field, false);
+        $id = $this->decodeHashid($hashid);
 
-		return true;
-	}
+        $entity->set($field, $id);
+        $entity->setDirty($field, false);
 
-	/**
-	 * Sets up hashid for model.
-	 *
-	 * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
-	 * @return bool True if save should proceed, false otherwise
-	 */
-	public function encode(EntityInterface $entity) {
-		$idField = $this->_primaryKey;
-		$id = $entity->get($idField);
-		if (!$id) {
-			return false;
-		}
+        return true;
+    }
 
-		$field = $this->_config['field'];
-		if (!$field) {
-			return false;
-		}
+    /**
+     * Sets up hashid for model.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
+     * @return bool True if save should proceed, false otherwise
+     */
+    public function encode(EntityInterface $entity)
+    {
+        $idField = $this->_primaryKey;
+        $id = $entity->get($idField);
+        if (!$id) {
+            return false;
+        }
 
-		$hashid = $this->encodeId($id);
+        $field = $this->_config['field'];
+        if (!$field) {
+            return false;
+        }
 
-		$entity->set($field, $hashid);
-		$entity->setDirty($field, false);
+        $hashid = $this->encodeId($id);
 
-		return true;
-	}
+        $entity->set($field, $hashid);
+        $entity->setDirty($field, false);
 
-	/**
-	 * Custom finder for hashids field.
-	 *
-	 * Options:
-	 * - hid (required), best to use HashidBehavior::HID constant
-	 * - noFirst (optional, to leave the query open for adjustments, no first() called)
-	 *
-	 * @param \Cake\ORM\Query $query Query.
-	 * @param array $options Array of options as described above
-	 * @return \Cake\ORM\Query
-	 */
-	public function findHashed(Query $query, array $options) {
-		$field = $this->_config['field'];
-		if (!$field) {
-			return $query;
-		}
+        return true;
+    }
 
-		$idField = $this->_primaryKey;
+    /**
+     * Custom finder for hashids field.
+     *
+     * Options:
+     * - hid (required), best to use HashidBehavior::HID constant
+     * - noFirst (optional, to leave the query open for adjustments, no first() called)
+     *
+     * @param \Cake\ORM\Query $query Query.
+     * @param array $options Array of options as described above
+     * @return \Cake\ORM\Query
+     */
+    public function findHashed(Query $query, array $options)
+    {
+        $field = $this->_config['field'];
+        if (!$field) {
+            return $query;
+        }
 
-		$query->formatResults(function ($results) use ($field, $idField) {
-			$newResult = [];
+        $idField = $this->_primaryKey;
 
-			$results->each(function ($row, $key) use ($field, $idField, &$newResult) {
-				if (!empty($row[$idField])) {
-					$row[$field] = $this->encodeId($row[$idField]);
-					if ($row instanceof EntityInterface) {
-						$row->setDirty($field, false);
-					}
-					$newResult[] = $row;
-				} elseif (is_string($row)) {
-					$newResult[$this->encodeId($key)] = $row;
-				} else {
-					$newResult[] = $row;
-				}
-			});
+        $query->formatResults(function ($results) use ($field, $idField) {
+            $newResult = [];
 
-			return new Collection($newResult);
-		});
+            $results->each(function ($row, $key) use ($field, $idField, &$newResult) {
+                if (!empty($row[$idField])) {
+                    $row[$field] = $this->encodeId($row[$idField]);
+                    if ($row instanceof EntityInterface) {
+                        $row->setDirty($field, false);
+                    }
+                    $newResult[] = $row;
+                } elseif (is_string($row)) {
+                    $newResult[$this->encodeId($key)] = $row;
+                } else {
+                    $newResult[] = $row;
+                }
+            });
 
-		if (!empty($options[static::HID])) {
-			$id = $this->decodeHashid($options[static::HID]);
-			$query->where([$idField => $id]);
-		}
+            return new Collection($newResult);
+        });
 
-		$first = $this->_config['findFirst'] === true ? 'first' : $this->_config['findFirst'];
-		if (!$first || !empty($options['noFirst'])) {
-			return $query;
-		}
-		return $query->first();
-	}
+        if (!empty($options[static::HID])) {
+            $id = $this->decodeHashid($options[static::HID]);
+            $query->where([$idField => $id]);
+        }
 
+        $first = $this->_config['findFirst'] === true ? 'first' : $this->_config['findFirst'];
+        if (!$first || !empty($options['noFirst'])) {
+            return $query;
+        }
+
+        return $query->first();
+    }
 }

--- a/src/Model/HashidTrait.php
+++ b/src/Model/HashidTrait.php
@@ -15,59 +15,65 @@ use Hashids\Hashids;
  *
  * @property array $_config
  */
-trait HashidTrait {
+trait HashidTrait
+{
 
-	/**
-	 * @param int $id
-	 * @return string
-	 */
-	public function encodeId($id) {
-		if ($id < 1 || !is_int($id)) {
-			throw new RecordNotFoundException('Invalid integer, the id must be >= 1.');
-		}
+    /**
+     * @param int $id
+     * @return string
+     */
+    public function encodeId($id)
+    {
+        if ($id < 1 || !is_int($id)) {
+            throw new RecordNotFoundException('Invalid integer, the id must be >= 1.');
+        }
 
-		$hashid = $this->_getHasher()->encode($id);
+        $hashid = $this->_getHasher()->encode($id);
 
-		if ($this->_config['debug']) {
-			$hashid .= '-' . $id;
-		}
-		return $hashid;
-	}
+        if ($this->_config['debug']) {
+            $hashid .= '-' . $id;
+        }
 
-	/**
-	 * @param string $hashid
-	 * @return int
-	 */
-	public function decodeHashid($hashid) {
-		if (is_array($hashid)) {
-			foreach ($hashid as $k => $v) {
-				$hashid[$k] = $this->decodeHashid($v);
-			}
-			return $hashid;
-		}
-		if ($this->_config['debug']) {
-			$hashid = substr($hashid, 0, strpos($hashid, '-'));
-		}
+        return $hashid;
+    }
 
-		$ids = $this->_getHasher()->decode($hashid);
-		return array_shift($ids);
-	}
+    /**
+     * @param string $hashid
+     * @return int
+     */
+    public function decodeHashid($hashid)
+    {
+        if (is_array($hashid)) {
+            foreach ($hashid as $k => $v) {
+                $hashid[$k] = $this->decodeHashid($v);
+            }
 
-	/**
-	 * @return \Hashids\Hashids
-	 */
-	protected function _getHasher() {
-		if (isset($this->_hashids)) {
-			return $this->_hashids;
-		}
+            return $hashid;
+        }
+        if ($this->_config['debug']) {
+            $hashid = substr($hashid, 0, strpos($hashid, '-'));
+        }
 
-		if ($this->_config['alphabet']) {
-			$this->_hashids = new Hashids($this->_config['salt'], $this->_config['minHashLength'], $this->_config['alphabet']);
-		} else {
-			$this->_hashids = new Hashids($this->_config['salt'], $this->_config['minHashLength']);
-		}
+        $ids = $this->_getHasher()->decode($hashid);
 
-		return $this->_hashids;
-	}
+        return array_shift($ids);
+    }
 
+    /**
+     * @return \Hashids\Hashids
+     */
+    protected function _getHasher()
+    {
+        if (isset($this->_hashids)) {
+            return $this->_hashids;
+        }
+
+        if ($this->_config['alphabet']) {
+            $this->_hashids = new Hashids($this->_config['salt'], $this->_config['minHashLength'], $this->_config['alphabet']);
+        } else {
+            $this->_hashids = new Hashids($this->_config['salt'], $this->_config['minHashLength']);
+        }
+
+        return $this->_hashids;
+    }
 }

--- a/src/View/Helper/HashidHelper.php
+++ b/src/View/Helper/HashidHelper.php
@@ -7,41 +7,42 @@ use Cake\View\Helper;
 use Cake\View\View;
 use Hashid\Model\HashidTrait;
 
-class HashidHelper extends Helper {
+class HashidHelper extends Helper
+{
 
-	use HashidTrait;
+    use HashidTrait;
 
-	/**
-	 * @var \Hashids\Hashids
-	 */
-	protected $_hashids;
+    /**
+     * @var \Hashids\Hashids
+     */
+    protected $_hashids;
 
-	/**
-	 * @var array
-	 */
-	protected $_defaultConfig = [
-		'salt' => null, // Please provide your own salt via Configure
-		'debug' => null, // Auto-detect
-		'minHashLength' => 0, // You can overwrite the Hashid defaults
-		'alphabet' => null, // You can overwrite the Hashid defaults
-	];
+    /**
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'salt' => null, // Please provide your own salt via Configure
+        'debug' => null, // Auto-detect
+        'minHashLength' => 0, // You can overwrite the Hashid defaults
+        'alphabet' => null, // You can overwrite the Hashid defaults
+    ];
 
-	/**
-	 * Constructor
-	 *
-	 * @param \Cake\View\View $View The View this helper is being attached to.
-	 * @param array $config Configuration settings for the helper.
-	 */
-	public function __construct(View $View, array $config = []) {
-		$defaults = (array)Configure::read('Hashid');
-		parent::__construct($View, $config + $defaults);
+    /**
+     * Constructor
+     *
+     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param array $config Configuration settings for the helper.
+     */
+    public function __construct(View $View, array $config = [])
+    {
+        $defaults = (array)Configure::read('Hashid');
+        parent::__construct($View, $config + $defaults);
 
-		if ($this->_config['salt'] === null) {
-			$this->_config['salt'] = Configure::read('Security.salt') ? sha1(Configure::read('Security.salt')) : null;
-		}
-		if ($this->_config['debug'] === null) {
-			$this->_config['debug'] = Configure::read('debug');
-		}
-	}
-
+        if ($this->_config['salt'] === null) {
+            $this->_config['salt'] = Configure::read('Security.salt') ? sha1(Configure::read('Security.salt')) : null;
+        }
+        if ($this->_config['debug'] === null) {
+            $this->_config['debug'] = Configure::read('debug');
+        }
+    }
 }

--- a/tests/Fixture/AddressesFixture.php
+++ b/tests/Fixture/AddressesFixture.php
@@ -6,48 +6,48 @@ use Cake\TestSuite\Fixture\TestFixture;
 /**
  * AddressFixture
  */
-class AddressesFixture extends TestFixture {
+class AddressesFixture extends TestFixture
+{
 
-	/**
-	 * Fields
-	 *
-	 * @var array
-	 */
-	public $fields = [
-		'id' => ['type' => 'integer'],
-		'user_id' => ['type' => 'integer', 'null' => true, 'default' => null],
-		'street' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100, 'comment' => ''],
-		'postal_code' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 10],
-		'city' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100],
-		'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
-		'modified' => ['type' => 'datetime', 'null' => true, 'default' => null],
-		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
-	];
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'user_id' => ['type' => 'integer', 'null' => true, 'default' => null],
+        'street' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100, 'comment' => ''],
+        'postal_code' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 10],
+        'city' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100],
+        'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
+        'modified' => ['type' => 'datetime', 'null' => true, 'default' => null],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
 
-	/**
-	 * Records
-	 *
-	 * @var array
-	 */
-	public $records = [
-		[
-			//'id' => '1', // ID 2 => 'jR'
-			'user_id' => 1,
-			'street' => 'Langstrasse 10',
-			'postal_code' => '101010',
-			'city' => 'München',
-			'created' => '2011-04-21 16:50:05',
-			'modified' => '2011-10-07 17:42:27',
-		],
-		[
-			//'id' => '2', // ID 2 => 'k5'
-			'user_id' => 2,
-			'street' => 'Xyz 20',
-			'postal_code' => '123',
-			'city' => 'NoHashId',
-			'created' => '2011-04-21 16:50:05',
-			'modified' => '2011-10-07 17:42:27',
-		],
-	];
-
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            //'id' => '1', // ID 2 => 'jR'
+            'user_id' => 1,
+            'street' => 'Langstrasse 10',
+            'postal_code' => '101010',
+            'city' => 'München',
+            'created' => '2011-04-21 16:50:05',
+            'modified' => '2011-10-07 17:42:27',
+        ],
+        [
+            //'id' => '2', // ID 2 => 'k5'
+            'user_id' => 2,
+            'street' => 'Xyz 20',
+            'postal_code' => '123',
+            'city' => 'NoHashId',
+            'created' => '2011-04-21 16:50:05',
+            'modified' => '2011-10-07 17:42:27',
+        ],
+    ];
 }

--- a/tests/Fixture/CommentsFixture.php
+++ b/tests/Fixture/CommentsFixture.php
@@ -6,35 +6,35 @@ use Cake\TestSuite\Fixture\TestFixture;
 /**
  * AddressFixture
  */
-class CommentsFixture extends TestFixture {
+class CommentsFixture extends TestFixture
+{
 
-	/**
-	 * Fields
-	 *
-	 * @var array
-	 */
-	public $fields = [
-		'id' => ['type' => 'integer'],
-		'address_id' => ['type' => 'integer', 'null' => true, 'default' => null],
-		'comment' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100, 'comment' => ''],
-		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
-	];
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'address_id' => ['type' => 'integer', 'null' => true, 'default' => null],
+        'comment' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100, 'comment' => ''],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
 
-	/**
-	 * Records
-	 *
-	 * @var array
-	 */
-	public $records = [
-		[
-			'address_id' => 1,
-			'comment' => 'Abc',
-		],
-		[
-			//'id' => '2', // ID 2 => 'k5'
-			'address_id' => 2,
-			'comment' => 'Def',
-		],
-	];
-
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'address_id' => 1,
+            'comment' => 'Abc',
+        ],
+        [
+            //'id' => '2', // ID 2 => 'k5'
+            'address_id' => 2,
+            'comment' => 'Def',
+        ],
+    ];
 }

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -6,31 +6,31 @@ use Cake\TestSuite\Fixture\TestFixture;
 /**
  *
  */
-class TagsFixture extends TestFixture {
+class TagsFixture extends TestFixture
+{
 
-	/**
-	 * Fields
-	 *
-	 * @var array
-	 */
-	public $fields = [
-		'id' => ['type' => 'integer'],
-		'name' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100, 'comment' => ''],
-		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
-	];
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'name' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 100, 'comment' => ''],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
 
-	/**
-	 * Records
-	 *
-	 * @var array
-	 */
-	public $records = [
-		[
-			'name' => 'Other',
-		],
-		[
-			'name' => 'Another',
-		],
-	];
-
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'name' => 'Other',
+        ],
+        [
+            'name' => 'Another',
+        ],
+    ];
 }

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -5,31 +5,31 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  */
-class UsersFixture extends TestFixture {
+class UsersFixture extends TestFixture
+{
 
-	/**
-	 * Fields
-	 *
-	 * @var array
-	 */
-	public $fields = [
-		'id' => ['type' => 'integer'],
-		'username' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 10],
-		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
-	];
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'username' => ['type' => 'string', 'null' => false, 'default' => '', 'length' => 10],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
 
-	/**
-	 * Records
-	 *
-	 * @var array
-	 */
-	public $records = [
-		[
-			'username' => 'Mr',
-		],
-		[
-			'username' => 'Mrs',
-		],
-	];
-
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'username' => 'Mr',
+        ],
+        [
+            'username' => 'Mrs',
+        ],
+    ];
 }

--- a/tests/TestCase/Model/Behavior/HashidBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/HashidBehaviorTest.php
@@ -7,418 +7,438 @@ use Cake\TestSuite\TestCase;
 use Hashids\Hashids;
 use Hashid\Model\Behavior\HashidBehavior;
 
-class HashidBehaviorTest extends TestCase {
-
-	/**
-	 * @var array
-	 */
-	public $fixtures = [
-		'plugin.Hashid.Addresses', 'plugin.Hashid.Users', 'plugin.Hashid.Comments'
-	];
-
-	/**
-	 * @var \Cake\ORM\Table;
-	 */
-	public $Addresses;
-
-	/**
-	 * @var \Cake\ORM\Table;
-	 */
-	public $Users;
-
-	/**
-	 * @var \Cake\ORM\Table;
-	 */
-	public $Comments;
-
-	/**
-	 * @return void
-	 */
-	public function setUp() {
-		parent::setUp();
-
-		Configure::write('Hashid', [
-				'debug' => false,
-			]
-		);
-		Configure::write('Security', [
-				'salt' => '' // For testing
-			]
-		);
-
-		$this->Addresses = TableRegistry::get('Hashid.Addresses');
-		$this->Addresses->addBehavior('Hashid.Hashid');
-
-		$this->Users = TableRegistry::get('Hashid.Users');
-		$this->Users->addBehavior('Hashid.Hashid');
-
-		$this->Comments = TableRegistry::get('Hashid.Comments');
-		$this->Comments->addBehavior('Hashid.Hashid');
-
-		//$this->Tags = TableRegistry::get('Hashid.Tags');
-		//$this->Tags->addBehavior('Hashid.Hashid');
-
-		$this->Addresses->hasMany('Hashid.Comments');
-		$this->Addresses->belongsTo('Hashid.Users');
-	}
-
-	/**
-	 * @return void
-	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		unset($this->Addresses);
-		TableRegistry::clear();
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testSave() {
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-		$this->assertTrue((bool)$res);
-
-		$this->assertNull($address->hash);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFind() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hashid');
-
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-
-		$id = $address->id;
-		$hasher = new Hashids();
-		$hashid = $hasher->encode($id);
-
-		$address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid])->first();
-		$this->assertTrue((bool)$address);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFindList() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hashid');
-		$this->Addresses->setDisplayField('city');
-		$this->Addresses->setPrimaryKey('id');
-
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-
-		$id = $address->id;
-		$hasher = new Hashids();
-		$hashid = $hasher->encode($id);
-
-		$addressList = $this->Addresses->find('list')->toArray();
-		$this->assertSame('Foo', $addressList[$hashid]);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testSaveDebugMode() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hashid');
-		$this->Addresses->behaviors()->Hashid->setConfig('debug', true);
-
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-		$this->assertTrue((bool)$res);
-
-		$this->assertSame('l5-3', $address->hashid);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testSaveDebugModeIdField() {
-		$this->Addresses->behaviors()->Hashid->setConfig('debug', true);
-
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-		$this->assertTrue((bool)$res);
-
-		$this->assertSame('l5-3', $address->id);
-
-		$address = $this->Addresses->get('l5-3');
-		$address->city = 'Foo Foo';
-		$res = $this->Addresses->save($address);
-		$this->assertTrue((bool)$res);
-
-		$address = $this->Addresses->get('l5-3');
-		$this->assertSame('Foo Foo', $address->city);
-
-		$address->city = 'Foo Bar';
-		$res = $this->Addresses->save($address);
-		$this->assertTrue((bool)$res);
-
-		$address->city = 'Foo Baz';
-		$res = $this->Addresses->save($address);
-		$this->assertTrue((bool)$res);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFindDebugMode() {
-		Configure::write('debug', true);
-		$this->Addresses->removeBehavior('Hashid');
-		$this->Addresses->addBehavior('Hashid.Hashid', ['field' => 'hashid', 'debug' => null]);
-
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-
-		$id = $address->id;
-		$hasher = new Hashids();
-		$hashid = $hasher->encode($id) . '-' . $id;
-
-		$address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid])->first();
-		$this->assertTrue((bool)$address);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testSaveWithField() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
-
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-		$this->assertTrue((bool)$res);
-		$this->assertSame(3, $address->id);
-
-		$hasher = new Hashids();
-		$expected = $hasher->encode($address->id);
-		$this->assertEquals($expected, $address->hash);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFindHashedWithField() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
-
-		$data = [
-			'city' => 'Foo'
-		];
-		$address = $this->Addresses->newEntity($data);
-		$res = $this->Addresses->save($address);
-
-		$hashid = $address->hash;
-
-		$address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid])->first();
-		$this->assertTrue((bool)$address);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFindWithFieldFalse() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', false);
-
-		$address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
-		$hashid = $this->Addresses->encodeId($address->id);
-
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
-
-		// Should also be included now
-		$address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
-		$this->assertSame($hashid, $address->hash);
-
-		// Should also be included now
-		$address = $this->Addresses->get($address->id);
-		$this->assertSame($hashid, $address->hash);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFindWithIdAsField() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'id');
-
-		$address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
-		$hashid = $this->Addresses->encodeId($address->getOriginal('id'));
-		$this->assertSame($hashid, $address->id);
-
-		$address = $this->Addresses->patchEntity($address, ['postal_code' => '678']);
-
-		$result = $this->Addresses->save($address);
-		$this->assertTrue((bool)$result);
-
-		$address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
-		$this->assertSame($hashid, $address->id);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testGet() {
-		$hashid = 'jR';
-		$address = $this->Addresses->get($hashid);
-		$this->assertSame($hashid, $address->id);
-	}
-
-	/**
-	 * @return void
-	*/
-	public function testFindHashed() {
-		$address = $this->Addresses->find()->where(['id' => 'jR'])->firstOrFail();
-		$this->assertTrue((bool)$address);
-	}
-
-	/**
-	 * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
-	 * @return void
-	 */
-	public function testFindHashedFail() {
-		$this->Addresses->find()->where(['id' => 'jRx'])->firstOrFail();
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFindFieldFalse() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', false);
-
-		$address = $this->Addresses->find()->where(['id' => 1])->firstOrFail();
-		$this->assertTrue((bool)$address);
-	}
-
-	/**
-	 * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
-	 * @return void
-	 */
-	public function testFindHashedFail2() {
-		$this->Addresses->find()->where(['id' => 1])->firstOrFail();
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testFindHashedWithFieldFirst() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
-		$this->Addresses->behaviors()->Hashid->setConfig('findFirst', true);
-
-		$hashid = 'k5';
-		$address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid]);
-		$this->assertSame(2, $address->id);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testEncode() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hid');
-
-		$address = $this->Addresses->newEntity();
-		$this->Addresses->encode($address);
-
-		$this->assertNull($address->hid);
-
-		$address->id = 2;
-		$this->Addresses->encode($address);
-
-		$expected = 'k5';
-		$this->assertSame($expected, $address->hid);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testEncodeWithOptions() {
-		$this->Addresses->behaviors()->Hashid->setConfig('field', 'hid');
-		$this->Addresses->behaviors()->Hashid->setConfig('minHashLength', 20);
-		$this->Addresses->behaviors()->Hashid->setConfig('alphabet', 'efghxyz123456789');
-
-		$address = $this->Addresses->newEntity();
-		$address->id = 2;
-		$this->Addresses->encode($address);
-
-		$expected = '63249351yx14x2z68758';
-		$this->assertSame($expected, $address->hid);
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testRecursive() {
-		$result = $this->Addresses->find()->contain([
-			$this->Users->getAlias(),
-			$this->Comments->getAlias(),
-		])->first();
-
-		$hashid = 'jR';
-		$this->assertSame($hashid, $result->id);
-
-		$this->assertSame(1, $result->comments[0]->id);
-		$this->assertSame(1, $result->user->id);
-
-		$this->Addresses->behaviors()->Hashid->setConfig('recursive', true);
-
-		$result = $this->Addresses->find()->contain([
-			$this->Users->getAlias(),
-			$this->Comments->getAlias(),
-		])->first();
-
-		$hashid = 'jR';
-		$this->assertSame($hashid, $result->id);
-		$this->assertSame($hashid, $result->comments[0]->id);
-		$this->assertSame($hashid, $result->user->id);
-	}
-
-	/**
-	 * testIsUniqueDomainRule method
-	 *
-	 * @return void
-	 */
-	public function testIsUniqueDomainRule() {
-		$data = [
-			'city' => 'Foo',
-		];
-
-		$address = $this->Addresses->newEntity($data);
-		$result = $this->Addresses->save($address);
-		$this->assertTrue((bool)$result);
-
-		$rules = $this->Addresses->rulesChecker();
-		$rules->add($rules->isUnique(['city']));
-
-		$address = $this->Addresses->newEntity($data);
-		$result = $this->Addresses->save($address);
-
-		$this->assertFalse((bool)$result);
-		$expected = [
-			'city' => [
-				'_isUnique' => 'This value is already in use',
-			],
-		];
-		$this->assertEquals($expected, $address->getErrors('city'), print_r($address->getErrors('city'), true));
-	}
-
+class HashidBehaviorTest extends TestCase
+{
+
+    /**
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.Hashid.Addresses', 'plugin.Hashid.Users', 'plugin.Hashid.Comments'
+    ];
+
+    /**
+     * @var \Cake\ORM\Table;
+     */
+    public $Addresses;
+
+    /**
+     * @var \Cake\ORM\Table;
+     */
+    public $Users;
+
+    /**
+     * @var \Cake\ORM\Table;
+     */
+    public $Comments;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        Configure::write('Hashid', [
+                'debug' => false,
+            ]);
+        Configure::write('Security', [
+                'salt' => '' // For testing
+            ]);
+
+        $this->Addresses = TableRegistry::get('Hashid.Addresses');
+        $this->Addresses->addBehavior('Hashid.Hashid');
+
+        $this->Users = TableRegistry::get('Hashid.Users');
+        $this->Users->addBehavior('Hashid.Hashid');
+
+        $this->Comments = TableRegistry::get('Hashid.Comments');
+        $this->Comments->addBehavior('Hashid.Hashid');
+
+        //$this->Tags = TableRegistry::get('Hashid.Tags');
+        //$this->Tags->addBehavior('Hashid.Hashid');
+
+        $this->Addresses->hasMany('Hashid.Comments');
+        $this->Addresses->belongsTo('Hashid.Users');
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        unset($this->Addresses);
+        TableRegistry::clear();
+    }
+
+    /**
+     * @return void
+     */
+    public function testSave()
+    {
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+        $this->assertTrue((bool)$res);
+
+        $this->assertNull($address->hash);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFind()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hashid');
+
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+
+        $id = $address->id;
+        $hasher = new Hashids();
+        $hashid = $hasher->encode($id);
+
+        $address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid])->first();
+        $this->assertTrue((bool)$address);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindList()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hashid');
+        $this->Addresses->setDisplayField('city');
+        $this->Addresses->setPrimaryKey('id');
+
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+
+        $id = $address->id;
+        $hasher = new Hashids();
+        $hashid = $hasher->encode($id);
+
+        $addressList = $this->Addresses->find('list')->toArray();
+        $this->assertSame('Foo', $addressList[$hashid]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSaveDebugMode()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hashid');
+        $this->Addresses->behaviors()->Hashid->setConfig('debug', true);
+
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+        $this->assertTrue((bool)$res);
+
+        $this->assertSame('l5-3', $address->hashid);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSaveDebugModeIdField()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('debug', true);
+
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+        $this->assertTrue((bool)$res);
+
+        $this->assertSame('l5-3', $address->id);
+
+        $address = $this->Addresses->get('l5-3');
+        $address->city = 'Foo Foo';
+        $res = $this->Addresses->save($address);
+        $this->assertTrue((bool)$res);
+
+        $address = $this->Addresses->get('l5-3');
+        $this->assertSame('Foo Foo', $address->city);
+
+        $address->city = 'Foo Bar';
+        $res = $this->Addresses->save($address);
+        $this->assertTrue((bool)$res);
+
+        $address->city = 'Foo Baz';
+        $res = $this->Addresses->save($address);
+        $this->assertTrue((bool)$res);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindDebugMode()
+    {
+        Configure::write('debug', true);
+        $this->Addresses->removeBehavior('Hashid');
+        $this->Addresses->addBehavior('Hashid.Hashid', ['field' => 'hashid', 'debug' => null]);
+
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+
+        $id = $address->id;
+        $hasher = new Hashids();
+        $hashid = $hasher->encode($id) . '-' . $id;
+
+        $address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid])->first();
+        $this->assertTrue((bool)$address);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSaveWithField()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
+
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+        $this->assertTrue((bool)$res);
+        $this->assertSame(3, $address->id);
+
+        $hasher = new Hashids();
+        $expected = $hasher->encode($address->id);
+        $this->assertEquals($expected, $address->hash);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindHashedWithField()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
+
+        $data = [
+            'city' => 'Foo'
+        ];
+        $address = $this->Addresses->newEntity($data);
+        $res = $this->Addresses->save($address);
+
+        $hashid = $address->hash;
+
+        $address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid])->first();
+        $this->assertTrue((bool)$address);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindWithFieldFalse()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', false);
+
+        $address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
+        $hashid = $this->Addresses->encodeId($address->id);
+
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
+
+        // Should also be included now
+        $address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
+        $this->assertSame($hashid, $address->hash);
+
+        // Should also be included now
+        $address = $this->Addresses->get($address->id);
+        $this->assertSame($hashid, $address->hash);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindWithIdAsField()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'id');
+
+        $address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
+        $hashid = $this->Addresses->encodeId($address->getOriginal('id'));
+        $this->assertSame($hashid, $address->id);
+
+        $address = $this->Addresses->patchEntity($address, ['postal_code' => '678']);
+
+        $result = $this->Addresses->save($address);
+        $this->assertTrue((bool)$result);
+
+        $address = $this->Addresses->find()->where(['city' => 'NoHashId'])->first();
+        $this->assertSame($hashid, $address->id);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGet()
+    {
+        $hashid = 'jR';
+        $address = $this->Addresses->get($hashid);
+        $this->assertSame($hashid, $address->id);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindHashed()
+    {
+        $address = $this->Addresses->find()->where(['id' => 'jR'])->firstOrFail();
+        $this->assertTrue((bool)$address);
+    }
+
+    /**
+     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
+     * @return void
+     */
+    public function testFindHashedFail()
+    {
+        $this->Addresses->find()->where(['id' => 'jRx'])->firstOrFail();
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindFieldFalse()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', false);
+
+        $address = $this->Addresses->find()->where(['id' => 1])->firstOrFail();
+        $this->assertTrue((bool)$address);
+    }
+
+    /**
+     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
+     * @return void
+     */
+    public function testFindHashedFail2()
+    {
+        $this->Addresses->find()->where(['id' => 1])->firstOrFail();
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindHashedWithFieldFirst()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hash');
+        $this->Addresses->behaviors()->Hashid->setConfig('findFirst', true);
+
+        $hashid = 'k5';
+        $address = $this->Addresses->find('hashed', [HashidBehavior::HID => $hashid]);
+        $this->assertSame(2, $address->id);
+    }
+
+    /**
+     * @return void
+     */
+    public function testEncode()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hid');
+
+        $address = $this->Addresses->newEntity();
+        $this->Addresses->encode($address);
+
+        $this->assertNull($address->hid);
+
+        $address->id = 2;
+        $this->Addresses->encode($address);
+
+        $expected = 'k5';
+        $this->assertSame($expected, $address->hid);
+    }
+
+    /**
+     * @return void
+     */
+    public function testEncodeWithOptions()
+    {
+        $this->Addresses->behaviors()->Hashid->setConfig('field', 'hid');
+        $this->Addresses->behaviors()->Hashid->setConfig('minHashLength', 20);
+        $this->Addresses->behaviors()->Hashid->setConfig('alphabet', 'efghxyz123456789');
+
+        $address = $this->Addresses->newEntity();
+        $address->id = 2;
+        $this->Addresses->encode($address);
+
+        $expected = '63249351yx14x2z68758';
+        $this->assertSame($expected, $address->hid);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRecursive()
+    {
+        $result = $this->Addresses->find()->contain([
+            $this->Users->getAlias(),
+            $this->Comments->getAlias(),
+        ])->first();
+
+        $hashid = 'jR';
+        $this->assertSame($hashid, $result->id);
+
+        $this->assertSame(1, $result->comments[0]->id);
+        $this->assertSame(1, $result->user->id);
+
+        $this->Addresses->behaviors()->Hashid->setConfig('recursive', true);
+
+        $result = $this->Addresses->find()->contain([
+            $this->Users->getAlias(),
+            $this->Comments->getAlias(),
+        ])->first();
+
+        $hashid = 'jR';
+        $this->assertSame($hashid, $result->id);
+        $this->assertSame($hashid, $result->comments[0]->id);
+        $this->assertSame($hashid, $result->user->id);
+    }
+
+    /**
+     * testIsUniqueDomainRule method
+     *
+     * @return void
+     */
+    public function testIsUniqueDomainRule()
+    {
+        $data = [
+            'city' => 'Foo',
+        ];
+
+        $address = $this->Addresses->newEntity($data);
+        $result = $this->Addresses->save($address);
+        $this->assertTrue((bool)$result);
+
+        $rules = $this->Addresses->rulesChecker();
+        $rules->add($rules->isUnique(['city']));
+
+        $address = $this->Addresses->newEntity($data);
+        $result = $this->Addresses->save($address);
+
+        $this->assertFalse((bool)$result);
+        $expected = [
+            'city' => [
+                '_isUnique' => 'This value is already in use',
+            ],
+        ];
+        $this->assertEquals($expected, $address->getErrors('city'), print_r($address->getErrors('city'), true));
+    }
 }

--- a/tests/TestCase/View/Helper/HashidHelperTest.php
+++ b/tests/TestCase/View/Helper/HashidHelperTest.php
@@ -10,114 +10,118 @@ use Hashid\View\Helper\HashidHelper;
 /**
  *
  */
-class HashidHelperTest extends TestCase {
+class HashidHelperTest extends TestCase
+{
 
-	/**
-	 * @var \Hashid\View\Helper\HashidHelper
-	 */
-	public $Hashid;
+    /**
+     * @var \Hashid\View\Helper\HashidHelper
+     */
+    public $Hashid;
 
-	/**
-	 * @var \Cake\Http\ServerRequest
-	 */
-	protected $request;
+    /**
+     * @var \Cake\Http\ServerRequest
+     */
+    protected $request;
 
-	/**
-	 * setUp method
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-		parent::setUp();
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
 
-		Configure::write('Hashid', [
-				'debug' => false,
-			]
-		);
-		Configure::write('Security', [
-				'salt' => '' // For testing
-			]
-		);
+        Configure::write('Hashid', [
+                'debug' => false,
+            ]);
+        Configure::write('Security', [
+                'salt' => '' // For testing
+            ]);
 
-		$this->request = $this->getMockBuilder(ServerRequest::class, [])->getMock();
-		$this->view = new View($this->request);
-		$this->Hashid = new HashidHelper($this->view);
-	}
+        $this->request = $this->getMockBuilder(ServerRequest::class, [])->getMock();
+        $this->view = new View($this->request);
+        $this->Hashid = new HashidHelper($this->view);
+    }
 
-	/**
-	 * tearDown method
-	 *
-	 * @return void
-	 */
-	public function tearDown() {
-		parent::tearDown();
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
 
-		unset($this->Hashid);
-	}
+        unset($this->Hashid);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function testEncodeDecode() {
-		$id = 1;
+    /**
+     * @return void
+     */
+    public function testEncodeDecode()
+    {
+        $id = 1;
 
-		$hashid = $this->Hashid->encodeId($id);
-		$this->assertSame('jR', $hashid);
+        $hashid = $this->Hashid->encodeId($id);
+        $this->assertSame('jR', $hashid);
 
-		$newId = $this->Hashid->decodeHashid($hashid);
-		$this->assertSame($id, $newId);
+        $newId = $this->Hashid->decodeHashid($hashid);
+        $this->assertSame($id, $newId);
 
-		$id = 999000000;
-		$hashid = $this->Hashid->encodeId($id);
-		$this->assertTrue(strlen($hashid) > 6);
+        $id = 999000000;
+        $hashid = $this->Hashid->encodeId($id);
+        $this->assertTrue(strlen($hashid) > 6);
 
-		$newId = $this->Hashid->decodeHashid($hashid);
-		$this->assertSame($id, $newId);
-	}
+        $newId = $this->Hashid->decodeHashid($hashid);
+        $this->assertSame($id, $newId);
+    }
 
-	/**
-	 * For some x64 systems this can lead to empty results, as they cannot work with strings
-	 * larger than 1 billion or sth...
-	 *
-	 * @return void
-	 */
-	public function testEncodeDecodeMax() {
-		$id = PHP_INT_MAX;
+    /**
+     * For some x64 systems this can lead to empty results, as they cannot work with strings
+     * larger than 1 billion or sth...
+     *
+     * @return void
+     */
+    public function testEncodeDecodeMax()
+    {
+        $id = PHP_INT_MAX;
 
-		$hashid = $this->Hashid->encodeId($id);
-		$this->assertTrue(strlen($hashid) > 6);
-	}
+        $hashid = $this->Hashid->encodeId($id);
+        $this->assertTrue(strlen($hashid) > 6);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function testEncodeDecodeSalt() {
-		Configure::write('Security.salt', 'foobar');
-		$this->Hashid = new HashidHelper($this->view);
+    /**
+     * @return void
+     */
+    public function testEncodeDecodeSalt()
+    {
+        Configure::write('Security.salt', 'foobar');
+        $this->Hashid = new HashidHelper($this->view);
 
-		$id = 1;
+        $id = 1;
 
-		$hashid = $this->Hashid->encodeId($id);
-		$this->assertSame('3B', $hashid);
+        $hashid = $this->Hashid->encodeId($id);
+        $this->assertSame('3B', $hashid);
 
-		$newId = $this->Hashid->decodeHashid($hashid);
-		$this->assertSame($id, $newId);
-	}
+        $newId = $this->Hashid->decodeHashid($hashid);
+        $this->assertSame($id, $newId);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function testEncodeDecodeDebug() {
-		Configure::write('Hashid.debug', true);
-		$this->Hashid = new HashidHelper($this->view);
+    /**
+     * @return void
+     */
+    public function testEncodeDecodeDebug()
+    {
+        Configure::write('Hashid.debug', true);
+        $this->Hashid = new HashidHelper($this->view);
 
-		$id = 1;
+        $id = 1;
 
-		$hashid = $this->Hashid->encodeId($id);
-		$this->assertSame('jR-1', $hashid);
+        $hashid = $this->Hashid->encodeId($id);
+        $this->assertSame('jR-1', $hashid);
 
-		$newId = $this->Hashid->decodeHashid($hashid);
-		$this->assertSame($id, $newId);
-	}
-
+        $newId = $this->Hashid->decodeHashid($hashid);
+        $this->assertSame($id, $newId);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,12 +8,12 @@ define('APP_DIR', 'src');
 
 define('APP', rtrim(sys_get_temp_dir(), DS) . DS . APP_DIR . DS);
 if (!is_dir(APP)) {
-	mkdir(APP, 0770, true);
+    mkdir(APP, 0770, true);
 }
 
 define('TMP', ROOT . DS . 'tmp' . DS);
 if (!is_dir(TMP)) {
-	mkdir(TMP, 0770, true);
+    mkdir(TMP, 0770, true);
 }
 
 define('CONFIG', dirname(__FILE__) . DS . 'config' . DS);
@@ -25,52 +25,52 @@ define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . 'src' . DS);
 
 Cake\Core\Configure::write('App', [
-	'namespace' => 'App'
+    'namespace' => 'App'
 ]);
 
 Cake\Core\Configure::write('debug', true);
 
 $cache = [
-	'default' => [
-		'engine' => 'File',
-		'path' => CACHE
-	],
-	'_cake_core_' => [
-		'className' => 'File',
-		'prefix' => 'crud_myapp_cake_core_',
-		'path' => CACHE . 'persistent/',
-		'serialize' => true,
-		'duration' => '+10 seconds'
-	],
-	'_cake_model_' => [
-		'className' => 'File',
-		'prefix' => 'crud_my_app_cake_model_',
-		'path' => CACHE . 'models/',
-		'serialize' => 'File',
-		'duration' => '+10 seconds'
-	]
+    'default' => [
+        'engine' => 'File',
+        'path' => CACHE
+    ],
+    '_cake_core_' => [
+        'className' => 'File',
+        'prefix' => 'crud_myapp_cake_core_',
+        'path' => CACHE . 'persistent/',
+        'serialize' => true,
+        'duration' => '+10 seconds'
+    ],
+    '_cake_model_' => [
+        'className' => 'File',
+        'prefix' => 'crud_my_app_cake_model_',
+        'path' => CACHE . 'models/',
+        'serialize' => 'File',
+        'duration' => '+10 seconds'
+    ]
 ];
 
 Cake\Cache\Cache::setConfig($cache);
 
 if (file_exists(CONFIG . 'app_local.php')) {
-	\Cake\Core\Configure::load('app_local', 'default');
+    \Cake\Core\Configure::load('app_local', 'default');
 }
 
 // Ensure default test connection is defined
 if (!getenv('db_class')) {
-	putenv('db_class=Cake\Database\Driver\Sqlite');
-	putenv('db_dsn=sqlite::memory:');
+    putenv('db_class=Cake\Database\Driver\Sqlite');
+    putenv('db_dsn=sqlite::memory:');
 }
 
 Cake\Datasource\ConnectionManager::setConfig('test', [
-	'className' => 'Cake\Database\Connection',
-	'driver' => getenv('db_class'),
-	'dsn' => getenv('db_dsn'),
-	'database' => getenv('db_database'),
-	'username' => getenv('db_username'),
-	'password' => getenv('db_password'),
-	'timezone' => 'UTC',
-	'quoteIdentifiers' => true,
-	'cacheMetadata' => true,
+    'className' => 'Cake\Database\Connection',
+    'driver' => getenv('db_class'),
+    'dsn' => getenv('db_dsn'),
+    'database' => getenv('db_database'),
+    'username' => getenv('db_username'),
+    'password' => getenv('db_password'),
+    'timezone' => 'UTC',
+    'quoteIdentifiers' => true,
+    'cacheMetadata' => true,
 ]);

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -3,6 +3,6 @@
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 
-Router::scope('/', function(RouteBuilder $routes) {
-	$routes->fallbacks();
+Router::scope('/', function (RouteBuilder $routes) {
+    $routes->fallbacks();
 });


### PR DESCRIPTION
This aim of this pull request is to swap the plugin from using the fig codesniffer to using the CakePHP version, so that the plugin matches the framework coding standard.

I have also run an automated `phpcbf` for fixes, which is why many files have changed.