### PR TITLE
Fix encodeId function.

### DIFF
--- a/src/Model/HashidTrait.php
+++ b/src/Model/HashidTrait.php
@@ -24,7 +24,7 @@ trait HashidTrait {
 	 */
 	public function encodeId($id) {
 		if ($id < 1 || !is_int($id)) {
-			throw new RecordNotFoundException('Invalid integer, the id must be >= 1.');
+			return false;
 		}
 
 		$hashid = $this->_getHasher()->encode($id);

--- a/src/Model/HashidTrait.php
+++ b/src/Model/HashidTrait.php
@@ -2,7 +2,6 @@
 
 namespace Hashid\Model;
 
-use Cake\Datasource\Exception\RecordNotFoundException;
 use Hashids\Hashids;
 
 /**
@@ -20,7 +19,6 @@ trait HashidTrait {
 	/**
 	 * @param int $id
 	 * @return string|null
-	 * @throws \Cake\Datasource\Exception\RecordNotFoundException
 	 */
 	public function encodeId($id) {
 		if ($id < 1 || !is_int($id)) {

--- a/src/Model/HashidTrait.php
+++ b/src/Model/HashidTrait.php
@@ -24,7 +24,6 @@ trait HashidTrait {
 	 */
 	public function encodeId($id) {
 		if ($id < 1 || !is_int($id)) {
-			// throw new RecordNotFoundException('Invalid integer, the id must be >= 1.');
 			return null;
 		}
 

--- a/src/Model/HashidTrait.php
+++ b/src/Model/HashidTrait.php
@@ -19,12 +19,13 @@ trait HashidTrait {
 
 	/**
 	 * @param int $id
-	 * @return string
+	 * @return string|null
 	 * @throws \Cake\Datasource\Exception\RecordNotFoundException
 	 */
 	public function encodeId($id) {
 		if ($id < 1 || !is_int($id)) {
-			return false;
+			// throw new RecordNotFoundException('Invalid integer, the id must be >= 1.');
+			return null;
 		}
 
 		$hashid = $this->_getHasher()->encode($id);


### PR DESCRIPTION
So I'm not entirely sure what's going on here, if this wasn't tested paginating using multiple contains that all have Hashid behavior, or what. But when I try to do that, I was getting "Invalid integer, the id must be >= 1." because it was trying to loop through records that had already been interpreted by hashid, and were therefore things like `jK-5` which is clearly not an int, causing an error to be thrown and my page not to render.

This fix, while simple and probably not the right fix, does remove the error and allow my page to render.